### PR TITLE
Prepare 1.43

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,7 @@
 Revision history for Perl extension Geo::IP.
+1.43 Dec 2nd 2013
+	- Fix test case ( Boris Zentner )
+	- Update time zones ( Boris Zentner )
 1.42 Jun 6th 2013
         - Fix testcase any CAPI >= 1.5.0 should work ( Boris Zentner )
         - Add new pure perl region code TH 81 Bueng Kan ( Boris Zentner )

--- a/META.json
+++ b/META.json
@@ -35,5 +35,5 @@
       }
    },
    "release_status" : "stable",
-   "version" : "1.40"
+   "version" : "1.43"
 }

--- a/META.yml
+++ b/META.yml
@@ -18,4 +18,4 @@ no_index:
     - t
     - inc
 requires: {}
-version: 1.40
+version: 1.43

--- a/lib/Geo/IP.pm
+++ b/lib/Geo/IP.pm
@@ -7,7 +7,7 @@ use vars qw($VERSION @EXPORT  $GEOIP_PP_ONLY @ISA $XS_VERSION);
 BEGIN { $GEOIP_PP_ONLY = 0 unless defined($GEOIP_PP_ONLY); }
 
 BEGIN {
-    $VERSION = '1.42';
+    $VERSION = '1.43';
     eval {
 
         # PERL_DL_NONLAZY must be false, or any errors in loading will just

--- a/t/20_min_capi_version.t
+++ b/t/20_min_capi_version.t
@@ -18,6 +18,6 @@ unless ( defined $capi_version ) {
   # ugh, we use the pure perl API
   ok( 1, 1, "Pure perl API - skip" );
 } else {
-  ok( $capi_version, qr/^1\.5\./, "This module only supports 1.5.x releases of the libGeoIP C API." );
+  ok( $capi_version, qr/^1\.[56]\./, "This module only supports >= 1.5.x releases of the libGeoIP C API." );
 }
 


### PR DESCRIPTION
Test accepts libgeoip 1.5.x and 1.6.x
